### PR TITLE
Fix when_to_turn_on computation

### DIFF
--- a/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
+++ b/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
@@ -215,10 +215,7 @@ variables:
     {% set hours = hours|int %}
     {% set slots = prices|list|length %}
     {% set is_25h = (slots == 25) %}
-    {% set result = [] %}
-    {% for _ in range(slots) %}
-      {% set result = result + [0] %}
-    {% endfor %}
+    {% set result = [0] * slots %}
     {% set data = namespace(
                 prices_list = prices|list,
                 result = result) %}

--- a/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
+++ b/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
@@ -207,11 +207,7 @@ variables:
     {% set hours = hours|int %}
     {% set slots = prices|list|length %}
     {% set is_25h = (slots == 25) %}
-    {% set result = [] %}
-    {% for _ in range(slots) %}
-      {% set result = result + [0] %}
-    {% endfor %}
-
+    {% set result = [0] * slots %}
     {{ result | list }}
 
   when_to_turn_on: >

--- a/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
+++ b/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
@@ -202,6 +202,18 @@ variables:
 
     {{ prices.data | list }}
 
+  intermediate_result: >
+    {% set time_gap = time_gap|int %}
+    {% set hours = hours|int %}
+    {% set slots = prices|list|length %}
+    {% set is_25h = (slots == 25) %}
+    {% set result = [] %}
+    {% for _ in range(slots) %}
+      {% set result = result + [0] %}
+    {% endfor %}
+
+    {{ result | list }}
+
   when_to_turn_on: >
     {% set time_gap = time_gap|int %}
     {% set hours = hours|int %}

--- a/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
+++ b/blueprints/automation/marc-romu_energy/energy--pvpc-optimizer__low-fare.yaml
@@ -202,14 +202,6 @@ variables:
 
     {{ prices.data | list }}
 
-  intermediate_result: >
-    {% set time_gap = time_gap|int %}
-    {% set hours = hours|int %}
-    {% set slots = prices|list|length %}
-    {% set is_25h = (slots == 25) %}
-    {% set result = [0] * slots %}
-    {{ result | list }}
-
   when_to_turn_on: >
     {% set time_gap = time_gap|int %}
     {% set hours = hours|int %}


### PR DESCRIPTION
I recently added this blueprint to my system but unfortunately it didn't work as expected due to the computation of `when_to_turn_on` being broken.

The inner `set` within the initialization for loop never updates the outer `result` variable. In the end `result` always ends up being `[]` rather than the expected list of `0`s. I've substituted it with the python one-liner to initialize a list with the same value N times and it now works properly.

For reference, putting this into the Debugger reveals the issue:

```
{% set result = [] %}
{% for _ in range(2) %}
  {% set result = result + [0] %}
{{ result | list }}
{% endfor %}
{{ result | list }}
```

This prints:

```
[0]

  
[0]

[]
```